### PR TITLE
Update LFB Login Functions.ahk

### DIFF
--- a/LFBot/Functions/LFB Login Functions.ahk
+++ b/LFBot/Functions/LFB Login Functions.ahk
@@ -67,6 +67,7 @@ ClickPlay()
 		{
 			ToolTip
 			Break
+			sleep, 12000
 		}
 	}
 	log("Done. Play button has clicked, the game has launch.", LogPath)


### PR DESCRIPTION
Added sleep on line 70, because it was clicking continuously. This is for those people who face a delay before trove opens. The thing is the clicking spams it and hangs the computer. So now there's a delay before each click.